### PR TITLE
convert string to number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,8 @@ export default class Values {
   }
 
   all(weight = 10) {
-    return [...this.tints(weight).reverse(), Object.assign(this), ...this.shades(weight)];
+    const numberWeight = parseInt(weight)
+    return [...this.tints(numberWeight).reverse(), Object.assign(this), ...this.shades(numberWeight)];
   }
 
   hexString() {


### PR DESCRIPTION
Issue: If a number is passed as a string the **all** method currently doesn't accept the string value, for example, 10 as '10'.
 
Solution: Added parseInt to convert string to number.